### PR TITLE
revert to traditional setup

### DIFF
--- a/kurtzweil/__init__.py
+++ b/kurtzweil/__init__.py
@@ -1,0 +1,1 @@
+from kurtzweil import app

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 
 [options]
 include_package_data = True
-packages = find_namespace:
+packages = find:
 python_requires = >=3.7
 
 [options.packages.find]


### PR DESCRIPTION
Don't rely on `find_namespace:` directive, since that's for [Namespace Packages](https://packaging.python.org/guides/packaging-namespace-packages/)